### PR TITLE
Add OpenRouter chat settings

### DIFF
--- a/DIFF_20250624_035946.md
+++ b/DIFF_20250624_035946.md
@@ -1,0 +1,6 @@
+- Added new OpenRouterAgent under agenthub/openrouter_agent with registration and README.
+- Updated agenthub/__init__.py to include OpenRouterAgent.
+- Extended frontend settings to support API key and base URL with new inputs in SettingModal.
+- Updated services and state to store new settings and send them to backend.
+- Added translation keys for new settings.
+- Modified backend agent creation to accept API key and base URL from client settings.

--- a/RECOMMENDATIONS_20250624_035950.md
+++ b/RECOMMENDATIONS_20250624_035950.md
@@ -1,0 +1,2 @@
+- Consider implementing validation for API key and base URL fields to provide immediate feedback.
+- Add unit tests for the new OpenRouterAgent behavior.

--- a/agenthub/__init__.py
+++ b/agenthub/__init__.py
@@ -7,6 +7,12 @@ from . import monologue_agent  # noqa: E402
 from . import codeact_agent  # noqa: E402
 from . import planner_agent  # noqa: E402
 from . import SWE_agent      # noqa: E402
+from . import openrouter_agent  # noqa: E402
 
-__all__ = ['monologue_agent', 'codeact_agent',
-           'planner_agent', 'SWE_agent']
+__all__ = [
+    'monologue_agent',
+    'codeact_agent',
+    'planner_agent',
+    'SWE_agent',
+    'openrouter_agent',
+]

--- a/agenthub/openrouter_agent/README.md
+++ b/agenthub/openrouter_agent/README.md
@@ -1,0 +1,3 @@
+# OpenRouter Agent
+
+This agent extends the existing `MonologueAgent` but is intended to be used with OpenRouter based LLM endpoints.

--- a/agenthub/openrouter_agent/__init__.py
+++ b/agenthub/openrouter_agent/__init__.py
@@ -1,0 +1,4 @@
+from opendevin.agent import Agent
+from .agent import OpenRouterAgent
+
+Agent.register('OpenRouterAgent', OpenRouterAgent)

--- a/agenthub/openrouter_agent/agent.py
+++ b/agenthub/openrouter_agent/agent.py
@@ -1,0 +1,7 @@
+from agenthub.monologue_agent.agent import MonologueAgent
+
+
+class OpenRouterAgent(MonologueAgent):
+    """Agent that uses OpenRouter for LLM routing."""
+
+    pass

--- a/frontend/src/components/SettingModal.tsx
+++ b/frontend/src/components/SettingModal.tsx
@@ -35,6 +35,12 @@ function InnerSettingModal({ isOpen, onClose }: Props): JSX.Element {
   const [language, setLanguage] = useState(
     currentSettings[ArgConfigType.LANGUAGE],
   );
+  const [apiKey, setApiKey] = useState(
+    currentSettings[ArgConfigType.LLM_API_KEY],
+  );
+  const [baseUrl, setBaseUrl] = useState(
+    currentSettings[ArgConfigType.LLM_BASE_URL],
+  );
 
   const { t } = useTranslation();
 
@@ -57,6 +63,8 @@ function InnerSettingModal({ isOpen, onClose }: Props): JSX.Element {
       [ArgConfigType.LLM_MODEL]: model ?? inputModel,
       [ArgConfigType.AGENT]: agent,
       [ArgConfigType.LANGUAGE]: language,
+      [ArgConfigType.LLM_API_KEY]: apiKey,
+      [ArgConfigType.LLM_BASE_URL]: baseUrl,
     });
     onClose();
   };
@@ -108,6 +116,20 @@ function InnerSettingModal({ isOpen, onClose }: Props): JSX.Element {
             </AutocompleteItem>
           )}
         </Autocomplete>
+        <input
+          className="bg-neutral-700 rounded-small p-2 mt-2"
+          placeholder={t(I18nKey.CONFIGURATION$API_KEY_INPUT_PLACEHOLDER)}
+          value={apiKey}
+          onChange={(e) => setApiKey(e.target.value)}
+          aria-label={t(I18nKey.CONFIGURATION$API_KEY_INPUT_LABEL)}
+        />
+        <input
+          className="bg-neutral-700 rounded-small p-2 mt-2"
+          placeholder={t(I18nKey.CONFIGURATION$BASE_URL_INPUT_PLACEHOLDER)}
+          value={baseUrl}
+          onChange={(e) => setBaseUrl(e.target.value)}
+          aria-label={t(I18nKey.CONFIGURATION$BASE_URL_INPUT_LABEL)}
+        />
         <Autocomplete
           defaultItems={supportedAgents.map((v: string) => ({
             label: v,

--- a/frontend/src/i18n/translation.json
+++ b/frontend/src/i18n/translation.json
@@ -167,6 +167,18 @@
     "es": "Idioma",
     "tr": "Dil"
   },
+  "CONFIGURATION$API_KEY_INPUT_LABEL": {
+    "en": "API Key"
+  },
+  "CONFIGURATION$API_KEY_INPUT_PLACEHOLDER": {
+    "en": "OpenRouter API key"
+  },
+  "CONFIGURATION$BASE_URL_INPUT_LABEL": {
+    "en": "Base URL"
+  },
+  "CONFIGURATION$BASE_URL_INPUT_PLACEHOLDER": {
+    "en": "https://openrouter.ai/api/v1"
+  },
   "CONFIGURATION$MODAL_CLOSE_BUTTON_LABEL": {
     "en": "Close",
     "zh-CN": "关闭",

--- a/frontend/src/services/settingsService.ts
+++ b/frontend/src/services/settingsService.ts
@@ -24,12 +24,16 @@ const DISPLAY_MAP: { [key: string]: string } = {
   LLM_MODEL: "model",
   AGENT: "agent",
   LANGUAGE: "language",
+  LLM_API_KEY: "api key",
+  LLM_BASE_URL: "base url",
 };
 
 const DEFAULT_SETTINGS: Settings = {
   LLM_MODEL: "gpt-3.5-turbo",
   AGENT: "MonologueAgent",
   LANGUAGE: "en",
+  LLM_API_KEY: "",
+  LLM_BASE_URL: "https://openrouter.ai/api/v1",
 };
 
 const getSettingOrDefault = (key: string): string => {
@@ -41,6 +45,8 @@ export const getCurrentSettings = (): Settings => ({
   LLM_MODEL: getSettingOrDefault("LLM_MODEL"),
   AGENT: getSettingOrDefault("AGENT"),
   LANGUAGE: getSettingOrDefault("LANGUAGE"),
+  LLM_API_KEY: getSettingOrDefault("LLM_API_KEY"),
+  LLM_BASE_URL: getSettingOrDefault("LLM_BASE_URL"),
 });
 
 // Function to merge and update settings

--- a/frontend/src/state/settingsSlice.ts
+++ b/frontend/src/state/settingsSlice.ts
@@ -11,6 +11,10 @@ export const settingsSlice = createSlice({
     [ArgConfigType.AGENT]: localStorage.getItem(ArgConfigType.AGENT) || "",
     [ArgConfigType.LANGUAGE]:
       localStorage.getItem(ArgConfigType.LANGUAGE) || "en",
+    [ArgConfigType.LLM_API_KEY]:
+      localStorage.getItem(ArgConfigType.LLM_API_KEY) || "",
+    [ArgConfigType.LLM_BASE_URL]:
+      localStorage.getItem(ArgConfigType.LLM_BASE_URL) || "",
   } as { [key: string]: string },
   reducers: {
     setByKey: (state, action) => {

--- a/frontend/src/types/ConfigType.tsx
+++ b/frontend/src/types/ConfigType.tsx
@@ -2,12 +2,16 @@ enum ArgConfigType {
   LLM_MODEL = "LLM_MODEL",
   AGENT = "AGENT",
   LANGUAGE = "LANGUAGE",
+  LLM_API_KEY = "LLM_API_KEY",
+  LLM_BASE_URL = "LLM_BASE_URL",
 }
 
 const SupportedSettings: string[] = [
   ArgConfigType.LLM_MODEL,
   ArgConfigType.AGENT,
   ArgConfigType.LANGUAGE,
+  ArgConfigType.LLM_API_KEY,
+  ArgConfigType.LLM_BASE_URL,
 ];
 
 export { ArgConfigType, SupportedSettings };

--- a/opendevin/server/agent/agent.py
+++ b/opendevin/server/agent/agent.py
@@ -102,8 +102,8 @@ class AgentUnit:
         }  # remove empty values, prevent FE from sending empty strings
         agent_cls = self.get_arg_or_default(args, ConfigType.AGENT)
         model = self.get_arg_or_default(args, ConfigType.LLM_MODEL)
-        api_key = config.get(ConfigType.LLM_API_KEY)
-        api_base = config.get(ConfigType.LLM_BASE_URL)
+        api_key = args.get(ConfigType.LLM_API_KEY, config.get(ConfigType.LLM_API_KEY))
+        api_base = args.get(ConfigType.LLM_BASE_URL, config.get(ConfigType.LLM_BASE_URL))
         container_image = config.get(ConfigType.SANDBOX_CONTAINER_IMAGE)
         max_iterations = self.get_arg_or_default(
             args, ConfigType.MAX_ITERATIONS)


### PR DESCRIPTION
## Summary
- create `OpenRouterAgent` registered in `agenthub`
- allow user to set API key and base URL in Settings modal
- persist new settings and send them to backend
- update backend agent creation to read API key and base URL from settings
- document updates and future recommendations

## Testing
- `pre-commit run --files opendevin/**/* agenthub/**/* --show-diff-on-failure --config ./dev_config/python/.pre-commit-config.yaml`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_685a2170b3a0832a8ec5a4e8afa41d8a