### PR TITLE
docs: add Astro UI setup instructions

### DIFF
--- a/DIFF_20250628_014950.md
+++ b/DIFF_20250628_014950.md
@@ -1,0 +1,28 @@
+diff --git a/README.md b/README.md
+index 7c581d3..b4df29b 100644
+--- a/README.md
++++ b/README.md
+@@ -220,6 +220,23 @@ Please note that the selection of these technologies is in progress, and additio
+ 
+ An alternative web interface built with Astro, React, and Tailwind can be found in the `astro-app` directory.
+ 
++### Local Development
++
++The frontend lives in `astro-app` and depends on Node.js.
++To start it locally, install dependencies and launch the development server:
++
++```bash
++cd astro-app
++npm install
++npm run dev
++```
++
++For a production build use:
++
++```bash
++npm run build
++```
++
+ 
+ <p align="right" style="font-size: 14px; color: #555; margin-top: 20px;">
+     <a href="#readme-top" style="text-decoration: none; color: #007bff; font-weight: bold;">

--- a/README.md
+++ b/README.md
@@ -220,6 +220,23 @@ Please note that the selection of these technologies is in progress, and additio
 
 An alternative web interface built with Astro, React, and Tailwind can be found in the `astro-app` directory.
 
+### Local Development
+
+The frontend lives in `astro-app` and depends on Node.js.
+To start it locally, install dependencies and launch the development server:
+
+```bash
+cd astro-app
+npm install
+npm run dev
+```
+
+For a production build use:
+
+```bash
+npm run build
+```
+
 
 <p align="right" style="font-size: 14px; color: #555; margin-top: 20px;">
     <a href="#readme-top" style="text-decoration: none; color: #007bff; font-weight: bold;">

--- a/RECOMMENDATIONS_20250628_014957.md
+++ b/RECOMMENDATIONS_20250628_014957.md
@@ -1,0 +1,2 @@
+- Document Node.js version requirement in the README or package.json.
+- Consider referencing `npm run preview` for a production preview step.


### PR DESCRIPTION
## Summary
- document local Astro UI setup in the README
- record diff and recommendations

## Testing
- `make lint` *(fails: Command not found: pre-commit)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'opendevin')*

------
https://chatgpt.com/codex/tasks/task_e_685f49cdec0c832abf5390b2fab4d051

## Summary by Sourcery

Add setup instructions for the Astro UI frontend to the project README and include diff record and recommendations files

Documentation:
- Document local Astro UI development workflow with install, dev, and build commands in the README

Chores:
- Add diff and recommendations markdown files recording the changes and suggestions for Node.js version requirement and preview step