### PR TITLE
Add rag builder tests

### DIFF
--- a/DIFF_20250628_020453.md
+++ b/DIFF_20250628_020453.md
@@ -1,0 +1,1 @@
+- Added `tests/test_rag_builder.py` covering `index_files` and `query` using stub LangChain classes.

--- a/RECOMMENDATIONS_20250628_020453.md
+++ b/RECOMMENDATIONS_20250628_020453.md
@@ -1,0 +1,1 @@
+- Consider integrating these stubbed dependencies into a fixtures module to reuse across tests.

--- a/tests/test_rag_builder.py
+++ b/tests/test_rag_builder.py
@@ -1,0 +1,75 @@
+import sys
+from types import ModuleType, SimpleNamespace
+from pathlib import Path
+
+
+class DummyEmbeddings:
+    def __init__(self, *_, **__):
+        pass
+
+
+class DummySplitter:
+    def __init__(self, *_, **__):
+        pass
+
+    def split_documents(self, docs):
+        return docs
+
+
+class DummyLoader:
+    def __init__(self, path):
+        self.path = path
+
+    def load(self):
+        text = Path(self.path).read_text()
+        return [SimpleNamespace(page_content=text)]
+
+
+class DummyStore:
+    def __init__(self, *_, **__):
+        self.docs = []
+
+    def add_documents(self, docs):
+        self.docs.extend(docs)
+
+    def persist(self):
+        pass
+
+    def similarity_search(self, text, k=4):
+        return self.docs[:k]
+
+
+# Install stub langchain modules before importing RagBuilder
+langchain_embeddings = ModuleType('langchain.embeddings')
+langchain_embeddings.HuggingFaceEmbeddings = DummyEmbeddings
+langchain_text_splitter = ModuleType('langchain.text_splitter')
+langchain_text_splitter.RecursiveCharacterTextSplitter = DummySplitter
+langchain_document_loaders = ModuleType('langchain.document_loaders')
+langchain_document_loaders.TextLoader = DummyLoader
+langchain_vectorstores = ModuleType('langchain.vectorstores')
+langchain_chroma = ModuleType('langchain.vectorstores.chroma')
+langchain_chroma.Chroma = DummyStore
+
+sys.modules.setdefault('langchain', ModuleType('langchain'))
+sys.modules['langchain.embeddings'] = langchain_embeddings
+sys.modules['langchain.text_splitter'] = langchain_text_splitter
+sys.modules['langchain.document_loaders'] = langchain_document_loaders
+sys.modules['langchain.vectorstores'] = langchain_vectorstores
+sys.modules['langchain.vectorstores.chroma'] = langchain_chroma
+
+
+def test_index_files_and_query(tmp_path):
+    from opendevin.rag.builder import RagBuilder
+
+    rb = RagBuilder(persist_dir=str(tmp_path / 'store'))
+
+    f1 = tmp_path / 'one.txt'
+    f2 = tmp_path / 'two.txt'
+    f1.write_text('alpha beta gamma')
+    f2.write_text('delta epsilon zeta')
+
+    rb.index_files([f1, f2])
+
+    assert rb.store.docs
+    results = rb.query('alpha', k=1)
+    assert results == ['alpha beta gamma']


### PR DESCRIPTION
## Summary
- add a rag builder test exercising index and query
- document the changes

## Testing
- `pre-commit run --files tests/test_rag_builder.py --config dev_config/python/.pre-commit-config.yaml`
- `PYTHONPATH=. pytest -q tests/test_rag_builder.py`

------
https://chatgpt.com/codex/tasks/task_e_685f49da9308832a96030c5620d4e028

## Summary by Sourcery

Add comprehensive tests for the RAG builder's indexing and querying functionality using stubbed LangChain classes

Enhancements:
- Implement dummy LangChain modules in tests to isolate and simulate embeddings, text splitting, document loading, and vector store behavior

Documentation:
- Add internal markdown notes summarizing the diff and recommending fixture reuse for stub dependencies

Tests:
- Introduce `tests/test_rag_builder.py` to verify `index_files` and `query` methods of `RagBuilder`