### PR TITLE
Add OpenRouter agent setup docs

### DIFF
--- a/DIFF_20250629_120512.md
+++ b/DIFF_20250629_120512.md
@@ -1,0 +1,2 @@
+- Extended agenthub/openrouter_agent/README.md with configuration instructions and an example code snippet for instantiating the agent.
+- Updated README.md to link to the OpenRouter Agent README for usage details.

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ After completing the MVP, the team will focus on research in various areas, incl
 * OpenDevin will issue many prompts to the LLM you configure. Most of these LLMs cost money--be sure to set spending limits and monitor usage.
 * OpenDevin runs `bash` commands within a Docker sandbox, so it should not affect your machine. But your workspace directory will be attached to that sandbox, and files in the directory may be modified or deleted.
 * Our default Agent is currently the MonologueAgent, which has limited capabilities, but is fairly stable. We're working on other Agent implementations, including [SWE Agent](https://swe-agent.com/). You can [read about our current set of agents here](./docs/documentation/Agents.md).
-A new **OpenRouterAgent** routes tasks to specialist agents and LLM models via OpenRouter.
+A new **OpenRouterAgent** routes tasks to specialist agents and LLM models via OpenRouter. See the [OpenRouter Agent README](agenthub/openrouter_agent/README.md) for configuration details.
 
 ## 🚀 Get Started
 The easiest way to run OpenDevin is inside a Docker container.

--- a/RECOMMENDATIONS_20250629_120515.md
+++ b/RECOMMENDATIONS_20250629_120515.md
@@ -1,0 +1,1 @@
+- Consider adding a dedicated "Agents" section in the main README to outline all available agents with links to their READMEs for easier navigation.

--- a/agenthub/openrouter_agent/README.md
+++ b/agenthub/openrouter_agent/README.md
@@ -3,3 +3,24 @@
 This agent coordinates multiple sub-agents and routes requests to the best LLM model available through the OpenRouter service.
 It dynamically selects between a coding specialist, planner, shell agent, or the default monologue agent based on the task description.
 Each sub-agent runs on its own LLM model allowing optimized performance for different workloads.
+
+## Configuration
+
+Set your OpenRouter credentials using the standard LLM variables:
+
+```bash
+export LLM_API_KEY="<your-openrouter-api-key>"
+export LLM_BASE_URL="https://openrouter.ai/api/v1"
+```
+
+## Example
+
+Instantiate the agent in Python with a configured `LLM`:
+
+```python
+from agenthub.openrouter_agent import OpenRouterAgent
+from opendevin.llm.llm import LLM
+
+llm = LLM(api_key="<your-openrouter-api-key>", base_url="https://openrouter.ai/api/v1")
+agent = OpenRouterAgent(llm)
+```


### PR DESCRIPTION
## Summary
- document how to configure OpenRouter agent
- link OpenRouter agent README from main README
- record diffs and recommendations per repo guidelines

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68612b6bbc44832aa9ddc81712a4c3da

## Summary by Sourcery

Add setup documentation for the OpenRouter agent and link it from the main README.

Documentation:
- Add configuration instructions and example usage snippet to agenthub/openrouter_agent README
- Link OpenRouter Agent README from the main README for configuration details
- Include DIFF_ and RECOMMENDATIONS_ files recording changes and guidelines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added detailed configuration and usage instructions for the OpenRouter Agent, including environment variable setup and example code.
  * Updated the main README to reference the OpenRouter Agent documentation for more information.
  * Suggested adding an "Agents" section to the main README for easier navigation to agent-specific guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->