### PR TITLE
Update Astro UI docs

### DIFF
--- a/DIFF_20250629_120453.md
+++ b/DIFF_20250629_120453.md
@@ -1,0 +1,3 @@
+Changes made on 2025-06-29 12:04:53 UTC:
+- In `README.md`, renamed the subsection `Local Development` under `Astro UI` to `Setup and Startup`.
+- Updated wording to emphasize that the frontend resides in `astro-app` and requires Node.js.

--- a/README.md
+++ b/README.md
@@ -220,9 +220,9 @@ Please note that the selection of these technologies is in progress, and additio
 
 An alternative web interface built with Astro, React, and Tailwind can be found in the `astro-app` directory.
 
-### Local Development
+### Setup and Startup
 
-The frontend lives in `astro-app` and depends on Node.js.
+The frontend resides in `astro-app` and requires Node.js.
 To start it locally, install dependencies and launch the development server:
 
 ```bash

--- a/RECOMMENDATIONS_20250629_120457.md
+++ b/RECOMMENDATIONS_20250629_120457.md
@@ -1,0 +1,3 @@
+Recommendations recorded on 2025-06-29 12:04:57 UTC:
+- Document the required Node.js version for the `astro-app` frontend in `README.md`.
+- Consider adding scripts in the root `package.json` to delegate frontend commands for convenience.


### PR DESCRIPTION
## Summary
- rename `Local Development` section to **Setup and Startup** under the Astro UI heading
- clarify that the frontend depends on Node.js and lives in `astro-app`
- add DIFF and RECOMMENDATIONS logs

## Testing
- `make lint` *(fails: pre-commit not installed)*
- `pytest -q` *(fails: module import errors)*

------
https://chatgpt.com/codex/tasks/task_e_68612b69463c832aa5767559c8cdfb7a