### PR TITLE
Add RagBuilder tests

### DIFF
--- a/DIFF_20250629_120338.md
+++ b/DIFF_20250629_120338.md
@@ -1,0 +1,2 @@
+- Updated `tests/test_rag_builder.py` to ensure the repository root is on `sys.path`.
+- Split the previous single test into `build_rag` helper, `test_index_files`, and `test_query`.

--- a/RECOMMENDATIONS_20250629_120338.md
+++ b/RECOMMENDATIONS_20250629_120338.md
@@ -1,0 +1,1 @@
+- Consider placing the langchain stubs used in `test_rag_builder.py` into a shared fixtures module for reuse in other tests.

--- a/tests/test_rag_builder.py
+++ b/tests/test_rag_builder.py
@@ -2,6 +2,9 @@ import sys
 from types import ModuleType, SimpleNamespace
 from pathlib import Path
 
+# Ensure project root is on the import path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
 
 class DummyEmbeddings:
     def __init__(self, *_, **__):
@@ -58,7 +61,7 @@ sys.modules['langchain.vectorstores'] = langchain_vectorstores
 sys.modules['langchain.vectorstores.chroma'] = langchain_chroma
 
 
-def test_index_files_and_query(tmp_path):
+def build_rag(tmp_path):
     from opendevin.rag.builder import RagBuilder
 
     rb = RagBuilder(persist_dir=str(tmp_path / 'store'))
@@ -69,7 +72,15 @@ def test_index_files_and_query(tmp_path):
     f2.write_text('delta epsilon zeta')
 
     rb.index_files([f1, f2])
+    return rb
 
-    assert rb.store.docs
+
+def test_index_files(tmp_path):
+    rb = build_rag(tmp_path)
+    assert len(rb.store.docs) == 2
+
+
+def test_query(tmp_path):
+    rb = build_rag(tmp_path)
     results = rb.query('alpha', k=1)
     assert results == ['alpha beta gamma']


### PR DESCRIPTION
## Summary
- update RagBuilder unit tests
- document changes

## Testing
- `pre-commit run --files tests/test_rag_builder.py --config dev_config/python/.pre-commit-config.yaml`
- `pytest tests/test_rag_builder.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68612b69c02c832aa52c853328dae487

## Summary by Sourcery

Update RagBuilder unit tests by ensuring proper import path configuration and refactoring tests into reusable helper and independent cases

Tests:
- Prepend the project root to sys.path for correct module imports in tests
- Introduce a build_rag helper function to initialize RagBuilder in tests
- Split the original combined test into separate test_index_files and test_query functions